### PR TITLE
Issue2

### DIFF
--- a/src/bmff.c
+++ b/src/bmff.c
@@ -54,7 +54,14 @@ size_t bmff_parse(BMFFContext *ctx, const uint8_t *data, size_t size, BMFFCode *
 
     while(ptr + 8 < end) {
 
-        uint32_t box_size = parse_u32(ptr);
+        uint64_t box_size = parse_u32(ptr);
+        if(box_size == 1) {
+            box_size = parse_u64(&ptr[8]);
+        }
+        if(box_size == 0) {
+            // box goes to the end of the file
+            box_size = (uint64_t)(end - ptr);
+        }
         // make sure we have enough data to parse this box, otherwise exit parsing
         if(ptr + box_size > end) {
             break;

--- a/src/boxes.h
+++ b/src/boxes.h
@@ -62,17 +62,15 @@ typedef enum {
 
 // All Boxes contain the base Box as the first item in the structure.
 typedef struct Box {
-    uint32_t        size;
+    uint64_t        size;
     uint8_t         type[4];
-    size_t          large_size;
     const uint8_t   *user_type;
 } Box;
 
 typedef struct FullBox {
     // Box
-    uint32_t        size;
+    uint64_t        size;
     uint8_t         type[4];
-    size_t          large_size;
     const uint8_t   *user_type;
     // FullBox items
     uint8_t     version;

--- a/src/parse.c
+++ b/src/parse.c
@@ -151,9 +151,10 @@ int parse_box(const uint8_t *data, size_t size, Box *box)
     ptr += 4;
 
     if(box->size == 1) {
-        ADV_PARSE_U64(box->large_size, ptr);
-    }else{
-        box->large_size = 0;
+        ADV_PARSE_U64(box->size, ptr);
+    }
+    if(box->size == 0) {
+        box->size = size;
     }
 
     if(box->type[0] == 'u' && box->type[1] == 'u' && box->type[2] == 'i' && box->type[3] == 'd') {
@@ -170,10 +171,6 @@ int parse_full_box(const uint8_t *data, size_t size, FullBox *box)
 {
     const uint8_t *ptr = data;
     ptr += parse_box(data, size, (Box*)box);
-
-    if(box->size == 1) {
-        ADV_PARSE_U64(box->large_size, ptr);
-    }
 
     box->version = *ptr;
     ptr++;

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CCDIR = coverage
 CCOBJDIR = $(CCDIR)/obj
-CFLAGS = -I../bin -L../bin
+CFLAGS = -I../bin -L../bin -Wfatal-errors
 LIBS = -lbmff
 
 .SECONDEXPANSION:

--- a/test/box_parse.c
+++ b/test/box_parse.c
@@ -239,9 +239,8 @@ void test_parse_box_large_size(void)
 
     res = _bmff_parse_box_media_data(&ctx, data, sizeof(data), (Box**)&box);
     test_assert_equal(res, BMFF_OK, "success");
-    test_assert_equal(box->box.size, 0x01, "size");
     test_assert_equal(strncmp(box->box.type, "mdat", 4), 0, "type");
-    test_assert_equal(box->box.large_size, 0x0B8CE9, "large size");
+    test_assert_equal(box->box.size, 0x0B8CE9, "size");
 
     bmff_context_destroy(&ctx);
 

--- a/test/box_parse.c
+++ b/test/box_parse.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 
+void test_parse_box_large_size(void);
 void test_parse_box_file_type(void);
 void test_parse_box_track_reference_type(void);
 void test_parse_box_null_media_header(void);
@@ -111,6 +112,7 @@ void test_parse_box_event_message(void);
 
 int main(int argc, char** argv)
 {
+    test_parse_box_large_size();
     test_parse_box_file_type();
     test_parse_box_track_reference_type();
     test_parse_box_null_media_header();
@@ -215,6 +217,35 @@ int main(int argc, char** argv)
     test_parse_box_event_message();
     //test_parse_box_();
     return 0;
+}
+
+void test_parse_box_large_size(void)
+{
+    test_start("test_parse_box_large_size");
+
+    BMFFContext ctx;
+    MediaDataBox *box;
+    BMFFCode res;
+
+    uint8_t data[] = {
+        0x00, 0x00, 0x00, 0x01,
+        'm', 'd', 'a', 't',
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x0B, 0x8C, 0xE9,
+        0x21, 0x11, 0x45, 0x00,
+    };
+
+    bmff_context_init(&ctx);
+
+    res = _bmff_parse_box_media_data(&ctx, data, sizeof(data), (Box**)&box);
+    test_assert_equal(res, BMFF_OK, "success");
+    test_assert_equal(box->box.size, 0x01, "size");
+    test_assert_equal(strncmp(box->box.type, "mdat", 4), 0, "type");
+    test_assert_equal(box->box.large_size, 0x0B8CE9, "large size");
+
+    bmff_context_destroy(&ctx);
+
+    test_end();
 }
 
 void test_parse_box_file_type(void)

--- a/test/parse.c
+++ b/test/parse.c
@@ -6,10 +6,12 @@
 char *test_data_pos = test_data_fmp4_mp4;
 
 void test_parse(void);
+void test_parse_large_box(void);
 
 int main(int argc, char** argv)
 {
     test_parse();
+    test_parse_large_box();
     return 0;
 }
 
@@ -65,6 +67,38 @@ void test_parse(void)
         // read 1024 bytes from the file until we reach the end of the file
         read = read_mp4(write_pos, 1, read_size);
     }
+
+    // end parsing
+    bmff_parse_end(&ctx);
+    // destory the context
+    bmff_context_destroy(&ctx);
+    // end the test
+    test_end();
+}
+
+void test_parse_large_box(void)
+{
+    test_start("test_parse_large_box");
+
+    // create a context for parsing
+    BMFFContext ctx;
+    bmff_context_init(&ctx);
+
+    // a simple mp4 to parse
+    uint8_t data[] = {
+        0x00, 0x00, 0x00, 0x01,
+        'm', 'd', 'a', 't',
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x18,
+        0x99, 0x99, 0x99, 0x99,
+        0x99, 0x99, 0x99, 0x99,
+    };
+    size_t data_size = sizeof(data);
+
+    // parse the data
+    BMFFCode res;
+    size_t parsed = bmff_parse(&ctx, data, data_size, &res);
+    test_assert_equal(parsed, data_size, "parsed data size");
 
     // end parsing
     bmff_parse_end(&ctx);


### PR DESCRIPTION
Fixing issue with large 8-byte box sizes not correctly being parsed.
Consolidated `large_size` and `size` into a single `size` property.
Added co64 output in example and fixed issues with parsing large files.