### PR TITLE
Extending Breadcrumb Length

### DIFF
--- a/examples/bmffinfo.c
+++ b/examples/bmffinfo.c
@@ -347,9 +347,19 @@ void on_event(BMFFContext *ctx, BMFFEventId event_id, const uint8_t *fourCC, voi
             printf("|     Default skip Byte Block: %d\n", box->default_skip_byte_block);
             printf("|     Default Is Protected: %s\n", box->default_is_protected == eBooleanTrue ? "Yes" : "No");
             printf("|     Default Per Sample IV size: %d\n", box->default_per_sample_iv_size);
-            printf("|     Default KID: 0x%02X%02X...\n", box->default_kid[0], box->default_kid[1]);
+            printf("|     Default KID: 0x");
+            for (uint8_t i = 0; i < box->default_per_sample_iv_size; ++i) {
+                printf("%02X", box->default_kid[i]);
+            }
+            printf("\n");
             printf("|     Default Constant IV Size: %d\n", box->default_constant_iv_size);
-            printf("|     Default Constant IV: 0x%02X%02X...\n", box->default_constant_iv[0], box->default_constant_iv[1]);
+            if (box->default_constant_iv_size > 0) {
+                printf("|     Default Constant IV: 0x");
+                for (uint8_t i = 0; i < box->default_per_sample_iv_size; ++i) {
+                    printf("%02X", box->default_constant_iv[i]);
+                }
+                printf("\n");
+            }
         }
 
         else if(strncmp("senc", fourCC, 4) == 0) {

--- a/src/bmff.h
+++ b/src/bmff.h
@@ -35,7 +35,7 @@
 
 // Software version, format MAJOR.MINOR.PATCH
 #define BMFF_VERSION                            "0.1.1"
-#define BMFF_BREADCRUMB_SIZE                    (50)
+#define BMFF_BREADCRUMB_SIZE                    (128)
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
extending breadcrumb length and printing out default key id in bmffinfo example